### PR TITLE
Correcting a wrong written "extension"

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -47,7 +47,7 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
+*.po
 
 # Django stuff:
 *.log


### PR DESCRIPTION
**Reasons for making this change:**

There was a wrong written "extension" in the translation section.

**Links to documentation supporting these rule changes:** 

https://docs.djangoproject.com/es/1.10/topics/i18n/translation/#comments-for-translators-in-templates

There was a wrong written extension in the "translation" section.
